### PR TITLE
Update mks monster8 for no bootloader

### DIFF
--- a/Firmware/FirmwareSource/Remora-OS5/TARGET_MONSTER8/system_clock.c
+++ b/Firmware/FirmwareSource/Remora-OS5/TARGET_MONSTER8/system_clock.c
@@ -35,7 +35,7 @@
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
 /* #define VECT_TAB_SRAM */
-#define VECT_TAB_OFFSET  0xC000 /*!< Vector Table base offset field.
+#define VECT_TAB_OFFSET  0x0000 /*!< Vector Table base offset field.
                                    This value must be a multiple of 0x200. */
 
 

--- a/Firmware/FirmwareSource/Remora-OS5/custom_targets.json
+++ b/Firmware/FirmwareSource/Remora-OS5/custom_targets.json
@@ -62,7 +62,7 @@
             "MPU"
         ],
         "device_name": "STM32F407VGTx",
-        "bootloader_supported": true
+        
     },
     "OCTOPUS_PRO_429": {
         "inherits": ["FAMILY_STM32"],

--- a/Firmware/FirmwareSource/Remora-OS5/mbed_app.json
+++ b/Firmware/FirmwareSource/Remora-OS5/mbed_app.json
@@ -30,7 +30,7 @@
             "target.features_add": ["STORAGE"]
         },
         "MONSTER8": {
-            "target.mbed_app_start": "0x0800C000",
+            
             "platform.stdio-baud-rate": 115200,
             "target.stdio_uart_tx": "PA_9",
             "target.stdio_uart_rx": "PA_10",


### PR DESCRIPTION
remove bootloader from monster8 firmware. firmware loads via sd but something is not working when trying to access the sdcard to load the config.json when running main program. writing over the bootloader solves this, but there is still an issue after power cycling the board after a successful boot, the sdcard doesnt work unless you eject and reinsert the sd card